### PR TITLE
#KM-47 Responsiveness for values section and quote request section on home page

### DIFF
--- a/app/components/Header.tsx
+++ b/app/components/Header.tsx
@@ -45,6 +45,7 @@ export default function Header() {
             alignItems="center"
             justifyContent={{ base: "flex-start", lg: "flex-end" }}
             gap={{ base: "0", lg: "24px" }}
+            overflow="hidden"
           >
             <ChakraLink
               href="/"
@@ -84,7 +85,6 @@ export default function Header() {
               icon={hamburger ? <FaXmark /> : <FaBars />}
             />
           </Box>
-          <Spacer></Spacer>
         </Grid>
         {hamburger && (
           <Grid

--- a/app/components/HomePage/CompanyValues.tsx
+++ b/app/components/HomePage/CompanyValues.tsx
@@ -1,5 +1,4 @@
 // LIBRARY IMPORTS
-import { ReactNode } from "react";
 import { PageHomeBlocksValues } from "@/tina/__generated__/types";
 import { TinaMarkdown } from "tinacms/dist/rich-text";
 import {
@@ -43,12 +42,16 @@ export default function CompanyValues(props: PageHomeBlocksValues) {
               maxW="1400px"
               bg="white"
               borderRadius="2xl"
-              px={32}
+              px={{ base: 8, md: 16, lg: 32 }}
               py={24}
-              spacing={36}
+              spacing={{ base: 8, md: 24, lg: 36 }}
             >
               {/* QUALITY VALUE CONTAINER */}
-              <HStack spacing={12} align="center">
+              <HStack
+                direction={{ base: "column", md: "row" }}
+                spacing={12}
+                align="center"
+              >
                 <VStack align="start" spacing={4}>
                   <Heading size="lg" color="brand.text">
                     {props.quality1?.title}
@@ -80,7 +83,11 @@ export default function CompanyValues(props: PageHomeBlocksValues) {
                 </Flex>
               </HStack>
               {/* ON-TIME VALUE CONTAINER */}
-              <HStack spacing={12} align="center">
+              <HStack
+                direction={{ base: "column", md: "row" }}
+                spacing={12}
+                align="center"
+              >
                 <Flex
                   p={4}
                   bg="brand.primary"
@@ -112,7 +119,11 @@ export default function CompanyValues(props: PageHomeBlocksValues) {
                 </VStack>
               </HStack>
               {/* COLLABORATION VALUE CONTAINER */}
-              <HStack spacing={12} align="center">
+              <HStack
+                direction={{ base: "column", md: "row" }}
+                spacing={12}
+                align="center"
+              >
                 <VStack align="start" spacing={4}>
                   <Heading size="lg" color="brand.text">
                     {props.quality3?.title}

--- a/app/components/HomePage/CompanyValues.tsx
+++ b/app/components/HomePage/CompanyValues.tsx
@@ -20,7 +20,7 @@ import ContentWrapper from "../ContentWrapper";
 // VALUES COMPONENT DEFINITION
 export default function CompanyValues(props: PageHomeBlocksValues) {
   return (
-    <Box position="relative">
+    <Box position="relative" overflow="hidden">
       <Image
         src={gearBackground}
         alt=""

--- a/app/components/HomePage/CompanyValues.tsx
+++ b/app/components/HomePage/CompanyValues.tsx
@@ -8,6 +8,7 @@ import {
   HStack,
   Icon,
   Text,
+  Stack,
   VStack,
 } from "@chakra-ui/react";
 import Image from "next/image";
@@ -43,16 +44,20 @@ export default function CompanyValues(props: PageHomeBlocksValues) {
               bg="white"
               borderRadius="2xl"
               px={{ base: 8, md: 16, lg: 32 }}
-              py={24}
+              py={{ base: 16, md: 24 }}
               spacing={{ base: 8, md: 24, lg: 36 }}
             >
               {/* QUALITY VALUE CONTAINER */}
-              <HStack
+              <Stack
                 direction={{ base: "column", md: "row" }}
                 spacing={12}
                 align="center"
               >
-                <VStack align="start" spacing={4}>
+                <VStack
+                  align={{ base: "center", md: "start" }}
+                  spacing={4}
+                  order={{ base: 2, md: 0 }}
+                >
                   <Heading size="lg" color="brand.text">
                     {props.quality1?.title}
                   </Heading>
@@ -78,18 +83,20 @@ export default function CompanyValues(props: PageHomeBlocksValues) {
                   borderRadius="2xl"
                   align="center"
                   justify="center"
+                  order={{ base: 1, md: 0 }}
                 >
                   <Icon as={FaRegStar} boxSize={24} color="white" />
                 </Flex>
-              </HStack>
+              </Stack>
               {/* ON-TIME VALUE CONTAINER */}
-              <HStack
+              <Stack
                 direction={{ base: "column", md: "row" }}
                 spacing={12}
                 align="center"
               >
                 <Flex
                   p={4}
+                  mt={{ base: 8 }}
                   bg="brand.primary"
                   borderRadius="2xl"
                   align="center"
@@ -97,7 +104,7 @@ export default function CompanyValues(props: PageHomeBlocksValues) {
                 >
                   <Icon as={FaRegClock} boxSize={24} color="white" />
                 </Flex>
-                <VStack align="start" spacing={4}>
+                <VStack align={{ base: "center", md: "start" }} spacing={4}>
                   <Heading size="lg" color="brand.text">
                     {props.quality2?.title}
                   </Heading>
@@ -117,14 +124,18 @@ export default function CompanyValues(props: PageHomeBlocksValues) {
                     }}
                   />
                 </VStack>
-              </HStack>
+              </Stack>
               {/* COLLABORATION VALUE CONTAINER */}
-              <HStack
+              <Stack
                 direction={{ base: "column", md: "row" }}
                 spacing={12}
                 align="center"
               >
-                <VStack align="start" spacing={4}>
+                <VStack
+                  align={{ base: "center", md: "start" }}
+                  spacing={4}
+                  order={{ base: 2, md: 0 }}
+                >
                   <Heading size="lg" color="brand.text">
                     {props.quality3?.title}
                   </Heading>
@@ -146,14 +157,16 @@ export default function CompanyValues(props: PageHomeBlocksValues) {
                 </VStack>
                 <Flex
                   p={4}
+                  mt={{ base: 8 }}
                   bg="brand.primary"
                   borderRadius="2xl"
                   align="center"
                   justify="center"
+                  order={{ base: 1, md: 0 }}
                 >
                   <Icon as={FaPeopleGroup} boxSize={24} color="white" />
                 </Flex>
-              </HStack>
+              </Stack>
             </VStack>
           </VStack>
         </ContentWrapper>

--- a/app/components/HomePage/RequestQuote.tsx
+++ b/app/components/HomePage/RequestQuote.tsx
@@ -1,6 +1,6 @@
 // LIBRARY IMPORTS
-import { Box, Flex, VStack, Text, HStack, Icon } from "@chakra-ui/react";
-import React, { ReactNode, useState } from "react";
+import { Box, VStack, Text, HStack, Icon } from "@chakra-ui/react";
+import React, { useState } from "react";
 import { FaRegClipboard, FaRegEnvelope, FaRegHandshake } from "react-icons/fa6";
 import Image from "next/image";
 import { PageHomeBlocksQuoteSection } from "@/tina/__generated__/types";
@@ -51,7 +51,6 @@ export default function RequestQuote(props: PageHomeBlocksQuoteSection) {
         bgImage={machineBackground.src}
         bg="rgba(11, 17, 62, 0.79)"
       >
-        <Flex></Flex>
         <Box
           bg="white"
           flex="1"

--- a/app/components/HomePage/RequestQuote.tsx
+++ b/app/components/HomePage/RequestQuote.tsx
@@ -1,5 +1,5 @@
 // LIBRARY IMPORTS
-import { Box, VStack, Text, HStack, Icon } from "@chakra-ui/react";
+import { Box, Flex, VStack, Text, HStack, Icon } from "@chakra-ui/react";
 import React, { ReactNode, useState } from "react";
 import { FaRegClipboard, FaRegEnvelope, FaRegHandshake } from "react-icons/fa6";
 import Image from "next/image";
@@ -40,15 +40,18 @@ export default function RequestQuote(props: PageHomeBlocksQuoteSection) {
           zIndex: -1,
         }}
       />
-      <HStack
-        px={10}
+      <Box
+        display="flex"
+        flexDirection={{ base: "column-reverse", lg: "row" }}
+        gap="4rem"
+        px={{ base: 12, md: 24, lg: 10 }}
         py={20}
-        spacing={16}
         justifyContent="space-around"
         mx="auto"
         bgImage={machineBackground.src}
         bg="rgba(11, 17, 62, 0.79)"
       >
+        <Flex></Flex>
         <Box
           bg="white"
           flex="1"
@@ -151,7 +154,7 @@ export default function RequestQuote(props: PageHomeBlocksQuoteSection) {
             </Box>
           </HStack>
         </VStack>
-      </HStack>
+      </Box>
     </Box>
   );
 }

--- a/app/components/HomePage/RequestQuote.tsx
+++ b/app/components/HomePage/RequestQuote.tsx
@@ -28,7 +28,7 @@ export default function RequestQuote(props: PageHomeBlocksQuoteSection) {
   } = props.requestQuoteForm || {};
 
   return (
-    <Box position="relative">
+    <Box position="relative" overflow="hidden">
       <Image
         src={machineBackground}
         alt=""

--- a/app/components/MachinesPage/Machines.tsx
+++ b/app/components/MachinesPage/Machines.tsx
@@ -33,7 +33,7 @@ export default function Machines({
               bg="white"
               width={"90%"}
               mx={"auto"}
-              maxW={{ base: "300px", sm: "600px", lg: "1000px", xl: "1500px" }}
+              maxW={{ base: "250px", md: "600px", lg: "950px", xl: "1200px" }}
             >
               <Heading
                 as="h2"


### PR DESCRIPTION
## Description
This PR works on changing the layout of the values section and quote section on the home page to a vertical layout on medium and small screens. Something is throwing off the layout on small and medium screens causing a horizontal scroll bar to appear. Maybe a fixed width? I can't tell what it is. @BrettEastman I know you mentioned this in your PR for responsiveness, but I believe we've added responsive layouts to all home page components so I'm a bit lost. Is the header/footer? (The header is also quite wonky on the smaller screens). I'd appreciate help debugging this
<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## Related Tickets & Documents
Works on #KM-47
<!--
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## Acceptance Criteria

- [ ] The company values section rearranges to a single vertical column on small and medium screens
- [x] The request a quote section rearranges to a single vertical column of first the text and then the form on small and medium screens
- [ ] The content fits into the screen size

<!-- Put an `x` between the brackets to mark complete (don't add spaces) e.g. -[x] -->
<!-- Include AC from the JIRA ticket https://lemon-zest.atlassian.net/jira/software/projects/UM/boards/2 -->

## What type of PR is this? (check all applicable)
<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|     | :sparkles: New feature     |
|  ✓ | 🎨 Style                   |
|     | :hammer: Refactoring       |
|     | 🔥 Performance Improvements|
|     | :bug: Bug fix              |
|     | :100: Add tests            |
|     | :link: Update dependencies |
|     | :scroll: Docs              |


## Mobile & Desktop Screenshots/Recordings
The breakpoints are not coming into play at all for the values section:
<img width="231" alt="Screenshot 2024-05-09 at 2 24 39 PM" src="https://github.com/wavecrestweb/kenworthy-machine/assets/115492619/e17becef-3d63-4dc3-acff-71ffd7f6f69d">

The 'Request a Quote' section on mobile screens, the layout changes but the width is off.
<img width="239" alt="Screenshot 2024-05-09 at 2 22 51 PM" src="https://github.com/wavecrestweb/kenworthy-machine/assets/115492619/21acf185-c0aa-4ebe-9f71-868c507d9ca2">

Note that in the mobile view, the header doesn't extend across the screen width and there is white space on the right:
<img width="227" alt="Screenshot 2024-05-09 at 2 23 44 PM" src="https://github.com/wavecrestweb/kenworthy-machine/assets/115492619/cc58b397-3a0d-4683-ad18-1db1314ea81b">

<!-- Visual changes require screenshots -->

## What I learned
It might have been easier if we started with responsiveness from the get-go, especially for the header and hero section and then followed suit for the rest of the sections on the page.

## Testing steps

1.  `git switch KM-47/chore-home-responsive`
2. `npm run dev`
3. Check out the home page at different screen sizes.
4. Debug the home page responsiveness issues.


## Added to documentation?
<!-- Put an `✓` for the applicable box: -->
|     | Type                       |
| --- | -------------------------- |
|     | 📜 README.md    |
| x  | 🙅 no documentation needed    |


## What gif best describes this PR?
  ![confused](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExdTB5bHZxZ2diZTd2bzZwcjVpNDNqeHNweXJ4b2dnZ3MwYnMwZmNoZCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/FcuiZUneg1YRAu1lH2/giphy.gif)
<!--
  to easily include a gif, go to giphy.com, copy the gif link (must be a gif, not a clip/video),
  and then insert it following this format:
  ![gif name](url)
  the name you choose is arbitrary as it won't show up,
  but be sure to include the exclamation mark, brackets, and parentheses
-->

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

  Before submitting a Pull Request, please ensure you've done the following:
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->
