### PR TITLE
Km 49/fix hamburger

### DIFF
--- a/app/components/CareersPage/Openings.tsx
+++ b/app/components/CareersPage/Openings.tsx
@@ -45,12 +45,13 @@ export default function Openings(props: OpeningsProps): JSX.Element {
           direction="column"
           gap={{ base: "3rem", sm: "4rem", "2xl": "6rem" }}
           pt={{ base: "3rem", "2xl": "4rem" }}
-          px={{ base: "1rem", md: "2rem" }}
           minW={{ base: "95vw" }}
         >
           {props.openingsList?.positions?.map((position, i) => (
             <Card
               key={i}
+              width={"90%"}
+              alignSelf={"center"}
               variant={{
                 base: "position_sm",
                 xl: "position_lg",

--- a/app/components/Footer.tsx
+++ b/app/components/Footer.tsx
@@ -1,8 +1,8 @@
 import {
   Box,
-  Heading,
   Grid,
   GridItem,
+  Heading,
   Link,
   LinkProps,
   Stack,

--- a/app/components/Header.tsx
+++ b/app/components/Header.tsx
@@ -32,7 +32,8 @@ export default function Header() {
             px={{ base: "2rem", md: "4rem" }}
             py={{ base: "1rem", md: "2rem" }}
             w={{ base: "20rem", md: "28rem", xl: "32rem" }}
-            minWidth="12rem"
+            h={{ base: "10rem", md: "12rem", xl: "14rem" }}
+            // minWidth="12rem"
           >
             <ChakraLink href="/">
               <Image src={logo} alt="Kenworthy Machine" />

--- a/app/components/Header.tsx
+++ b/app/components/Header.tsx
@@ -2,7 +2,7 @@
 
 // LIBRARY IMPORTS
 import { Link as ChakraLink } from "@chakra-ui/next-js";
-import { Box, Grid, IconButton, Stack } from "@chakra-ui/react";
+import { Box, Grid, GridItem, IconButton, Stack } from "@chakra-ui/react";
 import Image from "next/image";
 import { usePathname } from "next/navigation";
 import { useState } from "react";
@@ -21,17 +21,18 @@ export default function Header() {
   return (
     <Box backgroundColor="brand.primary" mx="auto" width="100%">
       <Stack>
-        <Grid
-          templateColumns={{
-            base: "1fr 1fr 1fr",
-            sm: "1fr 1fr 100px",
-            md: "500px 1fr 100px",
-          }}
+        <Box
+          display={"flex"}
+          alignItems={"center"}
+          justifyContent={"space-between"}
+          marginRight={{ base: "2rem", md: "4rem" }}
+          minHeight={150}
         >
           <Box
             px={{ base: "2rem", md: "4rem" }}
             py={{ base: "1rem", md: "2rem" }}
             w={{ base: "20rem", md: "28rem", xl: "32rem" }}
+            minWidth="12rem"
           >
             <ChakraLink href="/">
               <Image src={logo} alt="Kenworthy Machine" />
@@ -42,9 +43,8 @@ export default function Header() {
             display="flex"
             flexDirection="row"
             alignItems="center"
-            justifyContent="flex-end"
-            gap={{ base: "0", lg: "24px" }}
-            overflow="hidden"
+            justifyContent="flex-start"
+            gap={{ base: "12px", lg: "24px" }}
           >
             <ChakraLink
               href="/"
@@ -53,6 +53,8 @@ export default function Header() {
               }
               variant="navigation"
               visibility={{ base: "hidden", lg: "visible" }}
+              width={{ base: "0", lg: "auto" }}
+              height={{ base: "0", lg: "auto" }}
             >
               Home
             </ChakraLink>
@@ -66,6 +68,8 @@ export default function Header() {
               }
               variant="navigation"
               visibility={{ base: "hidden", lg: "visible" }}
+              width={{ base: "0", lg: "auto" }}
+              height={{ base: "0", lg: "auto" }}
             >
               Request a Quote
             </ChakraLink>
@@ -84,7 +88,7 @@ export default function Header() {
               icon={hamburger ? <FaXmark /> : <FaBars />}
             />
           </Box>
-        </Grid>
+        </Box>
 
         {hamburger && (
           <Grid

--- a/app/components/Header.tsx
+++ b/app/components/Header.tsx
@@ -2,7 +2,7 @@
 
 // LIBRARY IMPORTS
 import { Link as ChakraLink } from "@chakra-ui/next-js";
-import { Box, Grid, GridItem, IconButton, Stack } from "@chakra-ui/react";
+import { Box, Grid, IconButton, Stack } from "@chakra-ui/react";
 import Image from "next/image";
 import { usePathname } from "next/navigation";
 import { useState } from "react";
@@ -33,7 +33,6 @@ export default function Header() {
             py={{ base: "1rem", md: "2rem" }}
             w={{ base: "20rem", md: "28rem", xl: "32rem" }}
             h={{ base: "10rem", md: "12rem", xl: "14rem" }}
-            // minWidth="12rem"
           >
             <ChakraLink href="/">
               <Image src={logo} alt="Kenworthy Machine" />

--- a/app/components/Header.tsx
+++ b/app/components/Header.tsx
@@ -98,10 +98,11 @@ export default function Header() {
               lg: "repeat(4, 1fr)",
             }}
             gap="1.5rem"
-            mx={6}
+            w={{ base: "80%", md: "90%", lg: "100%" }}
+            mx={"auto"}
+            px="2rem"
             mb={6}
             borderRadius="50%"
-            maxW={{ base: "60%", md: "75%", lg: "100%" }}
           >
             <ChakraLink
               href="/request-quote"

--- a/app/components/Header.tsx
+++ b/app/components/Header.tsx
@@ -2,7 +2,7 @@
 
 // LIBRARY IMPORTS
 import { Link as ChakraLink } from "@chakra-ui/next-js";
-import { Box, Grid, IconButton, Spacer, Stack } from "@chakra-ui/react";
+import { Box, Grid, IconButton, Stack } from "@chakra-ui/react";
 import Image from "next/image";
 import { usePathname } from "next/navigation";
 import { useState } from "react";
@@ -19,31 +19,30 @@ export default function Header() {
   };
 
   return (
-    <Box backgroundColor="brand.primary" maxW="1728px" mx="auto" width="100%">
+    <Box backgroundColor="brand.primary" mx="auto" width="100%">
       <Stack>
         <Grid
           templateColumns={{
-            base: "1fr 1fr 20px",
+            base: "1fr 1fr 1fr",
             sm: "1fr 1fr 100px",
             md: "500px 1fr 100px",
           }}
         >
-          <Box>
-            <Box
-              px={"4rem"}
-              py={"2rem"}
-              w={{ base: "20rem", md: "28rem", xl: "32rem" }}
-            >
-              <ChakraLink href="/">
-                <Image src={logo} alt="Kenworthy Machine" />
-              </ChakraLink>
-            </Box>
+          <Box
+            px={{ base: "2rem", md: "4rem" }}
+            py={{ base: "1rem", md: "2rem" }}
+            w={{ base: "20rem", md: "28rem", xl: "32rem" }}
+          >
+            <ChakraLink href="/">
+              <Image src={logo} alt="Kenworthy Machine" />
+            </ChakraLink>
           </Box>
+
           <Box
             display="flex"
-            flexDirection={{ base: "row-reverse", lg: "row" }}
+            flexDirection="row"
             alignItems="center"
-            justifyContent={{ base: "flex-start", lg: "flex-end" }}
+            justifyContent="flex-end"
             gap={{ base: "0", lg: "24px" }}
             overflow="hidden"
           >
@@ -86,6 +85,7 @@ export default function Header() {
             />
           </Box>
         </Grid>
+
         {hamburger && (
           <Grid
             templateColumns={{

--- a/app/components/HomePage/Careers.tsx
+++ b/app/components/HomePage/Careers.tsx
@@ -57,7 +57,7 @@ export default function Careers(props: PageHomeBlocksCareerSection) {
               h3: (props) => (
                 <h3
                   style={{
-                    fontSize: "24px",
+                    fontSize: "20px",
                     color: "brand.text",
                     textAlign: "center",
                   }}
@@ -79,7 +79,7 @@ export default function Careers(props: PageHomeBlocksCareerSection) {
         </Box>
         <SimpleGrid
           spacing={{ base: 12, lg: 4 }}
-          gap={{ base: 19, lg: 200 }}
+          gap={{ base: 19, lg: 90 }}
           justifyContent={"flex-start"}
           templateColumns={{ base: "1fr", lg: "repeat(3, 1fr)" }}
           mt={8}

--- a/app/components/HomePage/Hero.tsx
+++ b/app/components/HomePage/Hero.tsx
@@ -5,7 +5,6 @@ import Image from "next/image";
 
 // LOCAL IMPORTS
 import heroImage from "../../../public/images/hero-photo.png";
-import ContentWrapper from "../ContentWrapper";
 
 // HERO COMPONENT DEFINITION
 export default function Hero(props: PageHomeBlocksHero) {
@@ -16,28 +15,27 @@ export default function Hero(props: PageHomeBlocksHero) {
       bg="white"
       minH="calc(38.25vw + 6rem)"
     >
-      <ContentWrapper>
-        <Image
-          src={heroImage}
-          alt={"various manufacturing machines in a shop"}
-        />
-        <Box
-          position="absolute"
-          w="93%"
-          left="50%"
-          transform="translate(-50%, -50%)"
-          height="10rem"
-          display="flex"
-          alignItems="center"
-          justifyContent="center"
-          bg="brand.primary"
-          opacity="90%"
-        >
-          <Heading fontSize={"48px"} size="xl" color="white">
-            {props.heading}
-          </Heading>
-        </Box>
-      </ContentWrapper>
+      <Image
+        src={heroImage}
+        alt={"various manufacturing machines in a shop"}
+        style={{ width: "100%", height: "auto", objectFit: "cover" }}
+      />
+      <Box
+        position="absolute"
+        w="93%"
+        left="50%"
+        transform="translate(-50%, -50%)"
+        height="10rem"
+        display="flex"
+        alignItems="center"
+        justifyContent="center"
+        bg="brand.primary"
+        opacity="90%"
+      >
+        <Heading fontSize={"48px"} size="xl" color="white">
+          {props.heading}
+        </Heading>
+      </Box>
     </Box>
   );
 }

--- a/app/components/MachinesPage/Machines.tsx
+++ b/app/components/MachinesPage/Machines.tsx
@@ -1,12 +1,12 @@
 //LIBRARY IMPORTS
-import { Link as ChakraLink } from "@chakra-ui/next-js";
-import { Heading, Text, SimpleGrid, Flex, Stack, Box } from "@chakra-ui/react";
 import { PageQuery } from "@/tina/__generated__/types";
+import { Link as ChakraLink } from "@chakra-ui/next-js";
+import { Box, Flex, Heading, SimpleGrid, Stack, Text } from "@chakra-ui/react";
 
 //LOCAL IMPORTS
-import MachineCarousel from "../HomePage/MachineCarousel";
-import ContentWrapper from "../ContentWrapper";
 import Card from "../Card/Card";
+import ContentWrapper from "../ContentWrapper";
+import MachineCarousel from "../HomePage/MachineCarousel";
 
 export type Block = NonNullable<
   NonNullable<PageQuery["page"]["blocks"]>

--- a/app/components/MachinesPage/MachinesPage.tsx
+++ b/app/components/MachinesPage/MachinesPage.tsx
@@ -1,14 +1,14 @@
 "use client";
 
 //LIBRARY IMPORTS
-import React, { useState } from "react";
-import { Grid } from "@chakra-ui/react";
-import { useTina } from "tinacms/dist/react";
 import { PageQuery } from "@/tina/__generated__/types";
+import { Grid } from "@chakra-ui/react";
+import { useState } from "react";
+import { useTina } from "tinacms/dist/react";
 
 //LOCAL IMPORTS
-import MachinesQuoteForm from "./MachinesQuoteForm";
 import Machines from "./Machines";
+import MachinesQuoteForm from "./MachinesQuoteForm";
 import MachinesSuccessMessage from "./MachinesSuccessMessage";
 
 export default function MachinesPage(props: {

--- a/app/components/MachinesPage/MachinesQuoteForm.tsx
+++ b/app/components/MachinesPage/MachinesQuoteForm.tsx
@@ -30,6 +30,7 @@ export default function MachinesQuoteForm(props: MachineLayoutQuoteFormProps) {
 
   return (
     <ChakraForm
+      width={"100vw"}
       pt={14}
       pb={24}
       bg="brand.primary"
@@ -119,6 +120,7 @@ export default function MachinesQuoteForm(props: MachineLayoutQuoteFormProps) {
             border="2px"
             id="details"
             fontSize="lg"
+            height={{ base: "150px", md: "100px" }}
             placeholder={
               props?.requestQuoteForm?.field3Placeholder ||
               "Share additional information or questions you have. Our team will personally connect with you about this quote."
@@ -138,7 +140,7 @@ export default function MachinesQuoteForm(props: MachineLayoutQuoteFormProps) {
           cursor={props?.buttonDisabled ? "not-allowed" : "pointer"}
           variant={props?.buttonDisabled ? "mc-white" : "mc-red"}
           fontSize="2xl"
-          w="md"
+          w="60%"
           type="submit"
           disabled={props?.buttonDisabled}
           onClick={() => {

--- a/app/components/MachinesPage/MachinesQuoteForm.tsx
+++ b/app/components/MachinesPage/MachinesQuoteForm.tsx
@@ -30,7 +30,7 @@ export default function MachinesQuoteForm(props: MachineLayoutQuoteFormProps) {
 
   return (
     <ChakraForm
-      width={"100vw"}
+      width={"100%"}
       pt={14}
       pb={24}
       bg="brand.primary"

--- a/app/components/MachinesPage/MachinesQuoteForm.tsx
+++ b/app/components/MachinesPage/MachinesQuoteForm.tsx
@@ -9,11 +9,11 @@ import {
   Textarea,
   VStack,
 } from "@chakra-ui/react";
-import React, { Dispatch, SetStateAction } from "react";
+import { Dispatch, SetStateAction } from "react";
 
 // LOCAL IMPORTS
-import { useSendQuoteRequest } from "@/utils/hooks/useSendQuoteRequest";
 import { PageViewMachinesBlocksQuoteSection } from "@/tina/__generated__/types";
+import { useSendQuoteRequest } from "@/utils/hooks/useSendQuoteRequest";
 
 // TYPE DEFINTIONS
 interface MachineLayoutQuoteFormProps

--- a/app/components/QuotePage/QuotePage.tsx
+++ b/app/components/QuotePage/QuotePage.tsx
@@ -1,15 +1,15 @@
 "use client";
 
 // LIBRARY IMPORTS
-import React, { useState } from "react";
-import { Box, VStack, Text, Stack } from "@chakra-ui/react";
+import { Box, Stack, Text, VStack } from "@chakra-ui/react";
 import Image from "next/image";
+import { useState } from "react";
 import { useTina } from "tinacms/dist/react";
 
 // LOCAL IMPORTS
+import gearBackground from "../../../public/images/machine-gear-background.png";
 import HomeQuoteForm from "../HomePage/HomeQuoteForm";
 import SuccessMessage from "./SuccessMessage";
-import gearBackground from "../../../public/images/machine-gear-background.png";
 
 // DEFINE TYPES
 interface PageRequestQuoteBlocksQuotePageForm {

--- a/app/global.css
+++ b/app/global.css
@@ -11,6 +11,10 @@
   --primary-red: #db0a40;
 }
 
+body {
+  width: fit-content;
+}
+
 .swiper-button-prev {
   color: (var(--background-color-med));
   border-radius: 50%;

--- a/app/global.css
+++ b/app/global.css
@@ -11,10 +11,6 @@
   --primary-red: #db0a40;
 }
 
-body {
-  width: fit-content;
-}
-
 .swiper-button-prev {
   color: (var(--background-color-med));
   border-radius: 50%;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -20,7 +20,7 @@ export default function RootLayout({
     <html lang="en" className={`${lato.variable} ${roboto_slab.variable}`}>
       <body>
         <Providers>
-          <Box zIndex={10} top="0" pos="sticky" width="100%">
+          <Box zIndex={10} top="0" pos="sticky">
             <Header />
           </Box>
           {children}


### PR DESCRIPTION
## Description

This pull request refactors the Hero and Header components to improve responsiveness and styling, and to prevent the hamburger from being covered up in the layout. It removes unnecessary wrappers, uses `display: flex` for better layout, and adjusts styles for the Kenworthy logo, hamburger menu, and form elements. Additionally, it cleans up code by reordering imports.

## Related Tickets & Documents
Fixes KM-49

## What type of PR is this? (check all applicable)
<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|     | :sparkles: New feature     |
|     | 🎨 Style                   |
|     | :hammer: Refactoring       |
|     | 🔥 Performance Improvements|
|  ✓  | :bug: Bug fix              |
|     | :100: Add tests            |
|     | :link: Update dependencies |
|     | :scroll: Docs              |


## Mobile & Desktop Screenshots/Recordings
<img width="500" alt="Screenshot 2024-07-18 at 3 50 53 PM" src="https://github.com/user-attachments/assets/04e3c88d-4796-4a0f-b74e-13c9ee240ef9">
<img width="500" alt="Screenshot 2024-07-18 at 3 51 16 PM" src="https://github.com/user-attachments/assets/eca66e77-4052-4670-8347-6001ab2689b4">
<img width="500" alt="Screenshot 2024-07-18 at 4 06 08 PM" src="https://github.com/user-attachments/assets/94943536-6fcb-4cda-99d7-bb95c5df3478">


## What I learned
I learned more about the keyword fit-content. When used with the width attribute on the body tag, it fixed the conflict we were having between the widths of the Request Quote section and the Header and Footer. However, I also learned that putting this on the body tag is not actually a good idea, so it was more of a blanket solution learning experience. I learned that with a great code reviewer colleague and a lot of deleting elements in the browser, you can pinpoint the exact problem, then pinpoint the exact line of code causing the bug.

## Testing steps
- ```git co KM-49/fix-hamburger```
- ```npm run dev```
- Try playing around with the header links


## What gif best describes this PR?
<!--
  to easily include a gif, go to giphy.com, copy the gif link (must be a gif, not a clip/video),
  and then insert it following this format:
  ![gif name](url)
  the name you choose is arbitrary as it won't show up,
  but be sure to include the exclamation mark, brackets, and parentheses
-->
![wegotthis](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExbHkzZ2UwcDNtZzA5emw3a3J2MHo3ZjBkM2hhMjAwcXNiNGliOG13byZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/WrmAysy2Zb2Z2qhVkS/giphy.gif)

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

  Before submitting a Pull Request, please ensure you've done the following:
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->
