### PR TITLE
#KM-48: Fix image fetching from Tina

### DIFF
--- a/.envTemplate
+++ b/.envTemplate
@@ -1,0 +1,9 @@
+EMAIL_TO=
+EMAIL_USER=
+EMAIL_PASSWORD=
+
+# email for resumes when there are no openings
+NEXT_PUBLIC_EMAIL_TO=
+
+NEXT_PUBLIC_TINA_CLIENT_ID=
+TINA_TOKEN=

--- a/next.config.js
+++ b/next.config.js
@@ -8,6 +8,16 @@ const nextConfig = {
       },
     ];
   },
+  images: {
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "assets.tina.io",
+        port: "",
+        pathname: `/${process.env.NEXT_PUBLIC_TINA_CLIENT_ID}/**`,
+      },
+    ],
+  },
 };
 
 module.exports = nextConfig;

--- a/public/admin/index.html
+++ b/public/admin/index.html
@@ -5,7 +5,7 @@
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>TinaCMS</title>
-    <script type="module" crossorigin src="/admin/assets/index-0c458041.js"></script>
+    <script type="module" crossorigin src="/admin/assets/index-f173281b.js"></script>
     <link rel="stylesheet" href="/admin/assets/index-ccfb8d68.css">
   </head>
   <body class="tina-tailwind">

--- a/public/admin/index.html
+++ b/public/admin/index.html
@@ -2,31 +2,70 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>TinaCMS</title>
+    <script type="module" crossorigin src="/admin/assets/index-0c458041.js"></script>
+    <link rel="stylesheet" href="/admin/assets/index-ccfb8d68.css">
   </head>
-
-  <!-- if development -->
-  <script type="module">
-    import RefreshRuntime from 'http://localhost:4001/@react-refresh'
-    RefreshRuntime.injectIntoGlobalHook(window)
-    window.$RefreshReg$ = () => {}
-    window.$RefreshSig$ = () => (type) => type
-    window.__vite_plugin_react_preamble_installed__ = true
-  </script>
-  <script type="module" src="http://localhost:4001/@vite/client"></script>
-  <script>
-  function handleLoadError() {
-    // Assets have failed to load
-    document.getElementById('root').innerHTML = '<style type="text/css"> #no-assets-placeholder body { font-family: sans-serif; font-size: 16px; line-height: 1.4; color: #333; background-color: #f5f5f5; } #no-assets-placeholder { max-width: 600px; margin: 0 auto; padding: 40px; text-align: center; background-color: #fff; box-shadow: 0px 0px 20px rgba(0, 0, 0, 0.1); } #no-assets-placeholder h1 { font-size: 24px; margin-bottom: 20px; } #no-assets-placeholder p { margin-bottom: 10px; } #no-assets-placeholder a { color: #0077cc; text-decoration: none; } #no-assets-placeholder a:hover { text-decoration: underline; } </style> <div id="no-assets-placeholder"> <h1>Failed loading TinaCMS assets</h1> <p> Your TinaCMS configuration may be misconfigured, and we could not load the assets for this page. </p> <p> Please visit <a href="https://tina.io/docs/tina-cloud/faq/#how-do-i-resolve-failed-loading-tinacms-assets-error">this doc</a> for help. </p> </div> </div>';
-  }
-  </script>
-  <script
-    type="module"
-    src="http://localhost:4001/src/main.tsx"
-    onerror="handleLoadError()"
-  ></script>
   <body class="tina-tailwind">
     <div id="root"></div>
+    <script>
+      function handleLoadError() {
+        console.error('Failed to load assets')
+        // Assets have failed to load
+        document.getElementById('root').innerHTML =
+          '<style type="text/css">\
+        #no-assets-placeholder body {\
+          font-family: sans-serif;\
+          font-size: 16px;\
+          line-height: 1.4;\
+          color: #333;\
+          background-color: #f5f5f5;\
+        }\
+        #no-assets-placeholder {\
+          max-width: 600px;\
+          margin: 0 auto;\
+          padding: 40px;\
+          text-align: center;\
+          background-color: #fff;\
+          box-shadow: 0px 0px 20px rgba(0, 0, 0, 0.1);\
+        }\
+        #no-assets-placeholder h1 {\
+          font-size: 24px;\
+          margin-bottom: 20px;\
+        }\
+        #no-assets-placeholder p {\
+          margin-bottom: 10px;\
+        }\
+        #no-assets-placeholder a {\
+          color: #0077cc;\
+          text-decoration: none;\
+        }\
+        #no-assets-placeholder a:hover {\
+          text-decoration: underline;\
+        }\
+        </style>\
+        <div id=\'no-assets-placeholder\'>\
+          <h1>Failed loading TinaCMS assets</h1>\
+          <p>\
+            Your TinaCMS configuration may be misconfigured, and we could not load\
+            the assets for this page.\
+          </p>\
+          <p>\
+            Please visit <a href="https://tina.io/docs/tina-cloud/faq/#how-do-i-resolve-failed-loading-tinacms-assets-error">this doc</a> for help.\
+          </p>\
+        </div>'
+      }
+
+      // Check if #root has childen after 2 seconds
+      // If not, we assume that the assets have failed to load
+      setTimeout(() => {
+        if (!document.getElementById('root').children.length) {
+          handleLoadError()
+        }
+      }, 2000)
+    </script>
+    
   </body>
 </html>


### PR DESCRIPTION
## Description

This PR fixes image fetching from TinaCMS that wasn't working in deployment. It was a simple matter of adding Tina media hostname to next.js config file to allow external images from that host.

I also added a .envTemplate file to keep track of all environmental variables. Please let me know if I'm missing anything, so I can add them as well.

## Related Tickets & Documents

Closes #KM-48

## Acceptance Criteria

- [x] Images that are fetched from TinaCMS are displayed properly

## What type of PR is this? (check all applicable)
<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
| `✓`    | :bug: Bug fix              |
| `✓`    | :scroll: Docs              |


## Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->

## What I learned


## Testing steps

1. `git switch KM-48/fix-tina-images`
2. `npx tinacms build -c "next dev"` to use Tina Cloud instead of localhost
3. Open http://localhost:3000 and check that images on machine cards are displayed properly
4. Navigate to Machines page and check that images on machine cards are displayed properly
5. Navigate to Careers page and check that the Hero image is displayed properly

## Added to documentation?
<!-- Put an `✓` for the applicable box: -->
|     | Type                       |
| --- | -------------------------- |
|     | 📜 README.md    |
|   `✓`  | 🙅 no documentation needed    |


## What gif best describes this PR?
  ![I see](https://giphy.com/gifs/ifhtfilms-shocked-gasp-unbelievable-2hRJI8uu3OTiR0f3PD)

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

  Before submitting a Pull Request, please ensure you've done the following:
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->
