### PR TITLE
#KM-52/Fix invalid field form submission

### DIFF
--- a/app/components/Footer.tsx
+++ b/app/components/Footer.tsx
@@ -8,6 +8,7 @@ import {
   Stack,
   Text,
 } from "@chakra-ui/react";
+import { Link as ChakraLink } from "@chakra-ui/next-js";
 import Image from "next/image";
 import { TinaMarkdown } from "tinacms/dist/rich-text";
 import { FooterNavLinks, FooterContactInfo } from "@/tina/__generated__/types";
@@ -46,13 +47,15 @@ export default function Footer(props: {
                 w="87%"
                 maxW={{ base: "10.375rem", md: "15rem", xl: "32rem" }}
               >
-                <Image
-                  alt="Kenworthy Machine"
-                  height={500}
-                  placeholder="empty"
-                  src={logo ?? ""}
-                  width={500}
-                />
+                <ChakraLink href="/">
+                  <Image
+                    alt="Kenworthy Machine"
+                    height={500}
+                    placeholder="empty"
+                    src={logo ?? ""}
+                    width={500}
+                  />
+                </ChakraLink>
               </Box>
               <>
                 {contactInfo?.map(

--- a/app/components/HomePage/Careers.tsx
+++ b/app/components/HomePage/Careers.tsx
@@ -1,4 +1,4 @@
-import { PageHomeBlocksCareerSection } from "@/tina/__generated__/types";
+// LIBRARY IMPORTS
 import {
   Box,
   Button,
@@ -7,7 +7,11 @@ import {
   Spacer,
   Stack,
 } from "@chakra-ui/react";
+import Link from "next/link";
 import { TinaMarkdown } from "tinacms/dist/rich-text";
+
+// LOCAL IMPORTS
+import { PageHomeBlocksCareerSection } from "@/tina/__generated__/types";
 import chalkboard from "../../../public/images/Chalkboard-User.svg";
 import heart from "../../../public/images/Heart-Pulse.svg";
 import graph from "../../../public/images/Upward-Graph.svg";
@@ -68,14 +72,17 @@ export default function Careers(props: PageHomeBlocksCareerSection) {
           />
         </Box>
         <Box mx="auto">
-          <Button
-            variant="mc-red"
-            w="250px"
-            position={{ base: "static", lg: "relative" }}
-            top={{ base: "0", lg: "85" }}
-          >
-            {props.buttonLabel}
-          </Button>
+          <Link href="/careers" passHref>
+            <Button
+              as="a"
+              variant="mc-red"
+              w="250px"
+              position={{ base: "static", lg: "relative" }}
+              top={{ base: "0", lg: "85" }}
+            >
+              {props.buttonLabel}
+            </Button>
+          </Link>
         </Box>
         <SimpleGrid
           spacing={{ base: 12, lg: 4 }}

--- a/app/components/HomePage/Careers.tsx
+++ b/app/components/HomePage/Careers.tsx
@@ -74,7 +74,6 @@ export default function Careers(props: PageHomeBlocksCareerSection) {
         <Box mx="auto">
           <Link href="/careers" passHref>
             <Button
-              as="a"
               variant="mc-red"
               w="250px"
               position={{ base: "static", lg: "relative" }}

--- a/app/components/HomePage/HomeQuoteForm.tsx
+++ b/app/components/HomePage/HomeQuoteForm.tsx
@@ -39,12 +39,19 @@ export default function HomeQuoteForm({
   setButtonDisabled,
 }: HomeQuoteFormProps) {
   // CUSTOM HOOK
-  const { register, handleSubmit, formState, onSubmit } = useSendQuoteRequest();
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isSubmitting },
+    onSubmit,
+  } = useSendQuoteRequest();
 
   return (
     <Box
       as="form"
-      onSubmit={handleSubmit((data) => onSubmit(data, setSubmitSuccessful))}
+      onSubmit={handleSubmit((data) =>
+        onSubmit(data, setSubmitSuccessful, setButtonDisabled!),
+      )}
       px={{ base: 2, md: 10, lg: 0 }}
     >
       <Text textAlign="center" fontSize="3xl" mt={8} color="brand.text">
@@ -124,16 +131,14 @@ export default function HomeQuoteForm({
           px={12}
           py={6}
           my={8}
-          cursor={buttonDisabled ? "not-allowed" : "pointer"}
-          variant={buttonDisabled ? "mc-white" : "mc-red"}
+          cursor={isSubmitting ? "not-allowed" : "pointer"}
+          variant={isSubmitting ? "mc-white" : "mc-red"}
           w="full"
           type="submit"
-          disabled={buttonDisabled}
-          onClick={
-            setButtonDisabled ? () => setButtonDisabled(true) : undefined
-          }
+          isLoading={isSubmitting}
+          loadingText="Submitting..."
         >
-          {buttonDisabled ? "Submitting..." : submitButtonText || "Submit"}
+          {submitButtonText || "Submit"}
         </Button>
       </VStack>
     </Box>

--- a/app/components/MachinesPage/MachinesQuoteForm.tsx
+++ b/app/components/MachinesPage/MachinesQuoteForm.tsx
@@ -35,7 +35,7 @@ export default function MachinesQuoteForm(props: MachineLayoutQuoteFormProps) {
       pb={24}
       bg="brand.primary"
       onSubmit={handleSubmit((data) =>
-        onSubmit(data, props.setSubmitSuccessful),
+        onSubmit(data, props.setSubmitSuccessful, props.setButtonDisabled!),
       )}
     >
       <Heading

--- a/utils/hooks/useSendQuoteRequest.ts
+++ b/utils/hooks/useSendQuoteRequest.ts
@@ -11,10 +11,12 @@ type UseSendQuoteRequestReturn = {
   handleSubmit: ReturnType<typeof useForm<FormData>>["handleSubmit"];
   formState: {
     errors: FieldErrors<FormData>;
+    isSubmitting: boolean;
   };
   onSubmit: (
     data: FormData,
     onSuccess: React.Dispatch<React.SetStateAction<boolean>>,
+    setButtonDisabled: React.Dispatch<React.SetStateAction<boolean>>,
   ) => void;
 };
 
@@ -23,14 +25,16 @@ export const useSendQuoteRequest = (): UseSendQuoteRequestReturn => {
     register,
     reset,
     handleSubmit,
-    formState: { errors },
+    formState: { errors, isSubmitting },
   } = useForm<FormData>();
   const toast = useToast();
 
   const onSubmit = (
     data: FormData,
     onSuccess: React.Dispatch<React.SetStateAction<boolean>>,
+    setButtonDisabled: React.Dispatch<React.SetStateAction<boolean>>,
   ) => {
+    setButtonDisabled(true);
     sendEmail(data)
       .then((response) => {
         if (!response.ok) {
@@ -62,13 +66,16 @@ export const useSendQuoteRequest = (): UseSendQuoteRequestReturn => {
           duration: 9000,
           isClosable: true,
         });
+      })
+      .finally(() => {
+        setButtonDisabled(false);
       });
   };
 
   return {
     register,
     handleSubmit: handleSubmit,
-    formState: { errors },
+    formState: { errors, isSubmitting },
     onSubmit,
   };
 };


### PR DESCRIPTION
## Description
This PR fixes the permanent loading state that occurred when a required form field was empty or invalid. This PR also links the 'Apply Now' button on the home page to the careers page, as well as the logo in the footer to the home page.
<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## Related Tickets & Documents
Closes #KM-52 
Closes #KM-53
Closes #KM-55
<!--
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## Acceptance Criteria
<!-- Put an `x` between the brackets to mark complete (don't add spaces) e.g. -[x] -->
<!-- Include AC from the JIRA ticket https://lemon-zest.atlassian.net/jira/software/projects/UM/boards/2 -->

- [x] The form submission button should properly reflect the submission state, becoming disabled only during the actual submission process and re-enabling after submission completes or fails.
- [x] Users should be able to resubmit the form after fixing validation errors, without the button remaining in a perpetual submitting state.

## What type of PR is this? (check all applicable)
<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|     | :sparkles: New feature     |
|     | 🎨 Style                   |
|     | :hammer: Refactoring       |
|     | 🔥 Performance Improvements|
|✓ | :bug: Bug fix              |
|     | :100: Add tests            |
|     | :link: Update dependencies |
|     | :scroll: Docs              |


## Mobile & Desktop Screenshots/Recordings
BEFORE:
<img width="498" alt="Screenshot 2024-09-23 at 10 59 12 AM" src="https://github.com/user-attachments/assets/24f6abcd-c5a7-4f57-84a3-4e788add23bd">

AFTER:
<img width="530" alt="Screenshot 2024-09-23 at 10 59 59 AM" src="https://github.com/user-attachments/assets/7d28886a-ce65-4dff-ac17-62f45542c75d">


<!-- Visual changes require screenshots -->

## What I learned
The `useSendQuoteRequest` hook now completely manages the form submission state, which is more logical as it all lives in one place. The original error occurred because the submit button's disabled state was being managed separately from the form's actual submission state.

## Testing steps

1. `git pull`
2. `git switch KM-52/fix-invalid-form-field`
3. `npm run dev`
4. Open `localhost:3000` and try to submit the form with no email, an invalid email, and/or no name. 
5. Be sure to note that this is a test email that can be ignored. 
6. Edit the invalid field and see if you can then submit.



## Added to documentation?
<!-- Put an `✓` for the applicable box: -->
|     | Type                       |
| --- | -------------------------- |
|     | 📜 README.md    |
|     | 🙅 no documentation needed    |


## What gif best describes this PR?
  ![gif name](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExOHo0b3Z3bG80eTBqNW00eXpxbGNvOXZ4Y2tvaWUybm9maDgxaG5saiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/xUOxfh6ZM75efM3Bqo/giphy.gif)
<!--
  to easily include a gif, go to giphy.com, copy the gif link (must be a gif, not a clip/video),
  and then insert it following this format:
  ![gif name](url)
  the name you choose is arbitrary as it won't show up,
  but be sure to include the exclamation mark, brackets, and parentheses
-->

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

  Before submitting a Pull Request, please ensure you've done the following:
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->
